### PR TITLE
add '\0' to str_copy

### DIFF
--- a/my_strcpy.c
+++ b/my_strcpy.c
@@ -19,6 +19,7 @@ char * str_copy( char *src, char *dest ){
       dest++;  // See above for pointer math
       index++;
    }
+   *dest = '\0';
    return ptr;
 }
 


### PR DESCRIPTION
It is possible that this line was left out of the str_copy function for purposes of teaching, but it is included in the reference code linked in the comments.  Adding this at line 22 will ensure that when a short string is copied into a longer memory space, the NULL character is added to end the string.